### PR TITLE
Adjust PR template: remove the checklist to "share in project-tech-infra" channel

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -63,7 +63,6 @@ Mark which one is correct. If `No` please detail why you cannot complete the reg
 # Pull Request Checklist
 
 - [ ] Fill out all sections above
-- [ ] Share pull request in PyLadies Slack channel #project-tech-infra
 
 /cc @pyladies/tech-and-infra-admins
 <!--


### PR DESCRIPTION
…fra" channel

I've added the GitHub App integration in Slack where PRs opened in this repo
will be automatically posted to the project-tech-infra Slack channel.
So I think it is not necessary to instruct the contributor to do so.
One less thing for them to do.

<!--
Please document the following for your pull request.
-->

# PyLadies Pull Request

## Is this pull requesting adding a PyLadies chapter website? 
<!--
Example of response:

Mark which one is correct.
-->

- [ ] Yes
- [x] No

## Is this pull request updating a PyLadies website?

- [ ] Yes
- [x] No

# Pull Request Checklist

- [x] Fill out all sections above

/cc @pyladies/tech-and-infra-admins
<!--
Add any other team you think should be subscribed to this issue

/cc your team
-->
