### PR TITLE
[CI] Fix Submodule Checkout in build.yml to Prevent Docker Build Failure

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,6 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       - name: Checkout repository and submodules
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           submodules: recursive

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,6 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       - name: Checkout repository and submodules
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           submodules: 'recursive'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,10 +13,11 @@ jobs:
   # This workflow contains a single job called "build"
   build:
     # The type of runner that the job will run on
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      - uses: actions/checkout@v2
-      - name: Checkout submodules
-        uses: textbook/git-checkout-submodule-action@master
+      - name: Checkout repository and submodules
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          submodules: recursive

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,4 +20,4 @@ jobs:
       - name: Checkout repository and submodules
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
-          submodules: recursive
+          submodules: 'recursive'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,4 +20,4 @@ jobs:
       - name: Checkout repository and submodules
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
-          submodules: 'recursive'
+          submodules: recursive


### PR DESCRIPTION
After the new Boston website [failed CI](https://github.com/pyladies/chapter-websites/actions/runs/15902283919/job/44847915533), investigated and found that the Docker container wasn't building due to `textbook/git-checkout-submodule-action@master` not being found.  Found that `textbook/git-checkout-submodule-action@master` is no longer maintained nor available.

This may not completely fix the problem, but it will remove the current failure and allow further troubleshooting.

`build.yml` has been updated with the following:

- [x] Upgraded & pinned the version of actions/checkout to [4.2.2](https://github.com/actions/checkout/commit/11bd71901bbe5b1630ceea73d27597364c9af683) (was at `actions/checkout@v2`)
- [x] Moved from `ubuntu/latest` to `ubuntu-24.04`, for more stability
- [x] Removed the no longer maintained `textbook/git-checkout-submodule-action@master`
- [x] Replaced `git-checkout-submodue-action` with `recursive` syntax for `actions/checkout` 

/cc @pyladies/tech-and-infra-admins
